### PR TITLE
refactor: split GlobalExceptionHandler into API and View handlers, ad…

### DIFF
--- a/src/main/java/com/project/demo/api/account/application/AccountService.java
+++ b/src/main/java/com/project/demo/api/account/application/AccountService.java
@@ -13,6 +13,7 @@ import com.project.demo.common.ApiResponse;
 import com.project.demo.common.BaseDTO;
 import com.project.demo.common.constant.AuthMsgKey;
 import com.project.demo.common.constant.CommonMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.constant.CommonConstant.ACCOUNT_KEY;
 import com.project.demo.common.util.MsgUtil;
 
@@ -37,7 +38,7 @@ public class AccountService {
             return passwordMatch(dto.getUserPwd(), dto.getUserSessionDTO().getUserSeq());
         } catch (Exception e) {
             log.error(">>>> AccountService::passwordVerify: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -62,7 +63,7 @@ public class AccountService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()));
         } catch (Exception e) {
             log.error(">>>> AccountService::passwordUpdate: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -80,7 +81,7 @@ public class AccountService {
             return ApiResponse.success();
         } catch (Exception e) {
             log.error(">>>> AccountService::passwordDelay: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -101,7 +102,7 @@ public class AccountService {
             return ApiResponse.error(msgUtil.getMessage(AuthMsgKey.BAD_CREDENTIALS.getKey()));
         } catch (Exception e) {
             log.error(">>>> AccountService::passwordMatch: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/board/application/BoardService.java
+++ b/src/main/java/com/project/demo/api/board/application/BoardService.java
@@ -22,6 +22,7 @@ import com.project.demo.common.constant.CommonConstant.MODEL_KEY;
 import com.project.demo.common.constant.CommonConstant.ROLE_KEY;
 import com.project.demo.common.constant.CommonConstant.SESSION_KEY;
 import com.project.demo.common.constant.CommonMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.util.MsgUtil;
 import com.project.demo.common.util.SessionUtil;
 
@@ -56,7 +57,7 @@ public class BoardService {
             return ApiResponse.success(dataMap);
         } catch (Exception e) {
             log.error(">>>> BoardService::findAll: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -80,7 +81,7 @@ public class BoardService {
             return ApiResponse.success(data);
         } catch (Exception e) {
             log.error(">>>> BoardService::findById: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -110,7 +111,7 @@ public class BoardService {
             return ApiResponse.success();
         } catch (Exception e) {
             log.error(">>>> BoardService::updateViewCnt: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -136,7 +137,7 @@ public class BoardService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), entity.getBoardSeq());
         } catch (Exception e) {
             log.error(">>>> BoardService::create: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -164,7 +165,7 @@ public class BoardService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()));
         } catch (Exception e) {
             log.error(">>>> BoardService::delete: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -201,7 +202,7 @@ public class BoardService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), dto.getBoardSeq());
         } catch (Exception e) {
             log.error(">>>> BoardService::update: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/code/application/CodeService.java
+++ b/src/main/java/com/project/demo/api/code/application/CodeService.java
@@ -9,6 +9,7 @@ import com.project.demo.api.code.infrastructure.CmmCdRepository;
 import com.project.demo.api.common.application.dto.SelectBoxDTO;
 import com.project.demo.common.ApiResponse;
 import com.project.demo.common.constant.CommonMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.util.MsgUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class CodeService {
             return ApiResponse.success(cmmCdRepository.findSelectOptions(grpCd));
         } catch (Exception e) {
             log.error(">>>> CodeService::getCode: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/common/application/EnumService.java
+++ b/src/main/java/com/project/demo/api/common/application/EnumService.java
@@ -11,6 +11,7 @@ import org.springframework.util.StringUtils;
 import com.project.demo.api.common.application.dto.SelectBoxDTO;
 import com.project.demo.common.ApiResponse;
 import com.project.demo.common.constant.CommonMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.util.MsgUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -50,9 +51,12 @@ public class EnumService {
                                             }
                                         })
                                         .collect(Collectors.toList()));
+        } catch (ClassNotFoundException e) {
+            log.error(">>>> EnumService::getEnum - 클래스 찾기 실패: ", e);
+            throw new CustomException("클래스를 찾을 수 없습니다: " + enumFillPath, HttpStatus.BAD_REQUEST, e);
         } catch (Exception e) {
             log.error(">>>> EnumService::getEnum: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/encrypt/application/EncryptionService.java
+++ b/src/main/java/com/project/demo/api/encrypt/application/EncryptionService.java
@@ -19,6 +19,7 @@ import com.project.demo.api.encrypt.infrastructure.RSAUtil;
 import com.project.demo.common.ApiResponse;
 import com.project.demo.common.constant.CommonMsgKey;
 import com.project.demo.common.constant.EncryptionMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.util.MsgUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -39,7 +40,7 @@ public class EncryptionService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), encryptStr);
         } catch (Exception e) {
             log.error(">>>> EncryptionService::jasyptEncrypt: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw e;
         }
     }
 
@@ -54,7 +55,7 @@ public class EncryptionService {
             return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(EncryptionMsgKey.FAILED_JASYPT_DECRYPT.getKey()));
         } catch (Exception e) {
             log.error(">>>> EncryptionService::jasyptDecrypt: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw e;
         }
     }
 
@@ -67,7 +68,7 @@ public class EncryptionService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), encryptStr);
         } catch (Exception e) {
             log.error(">>>> EncryptionService::bcryptEncrypt: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw e;
         }
     }
 
@@ -79,7 +80,7 @@ public class EncryptionService {
             return ApiResponse.success(msgUtil.getMessage((encoder.matches(dto.getTargetText(), dto.getSecretKey()) ? EncryptionMsgKey.SUCCUESS_MATCHES_Y.getKey() : EncryptionMsgKey.SUCCUESS_MATCHES_N.getKey())));
         } catch (Exception e) {
             log.error(">>>> EncryptionService::bcryptEncrypt: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw e;
         }
     }
 
@@ -91,7 +92,7 @@ public class EncryptionService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), encodeStr);
         } catch (Exception e) {
             log.error(">>>> EncryptionService::base64Encode: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw e;
         }
     }
 
@@ -103,10 +104,10 @@ public class EncryptionService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), decodeStr);
         } catch (IllegalArgumentException e) {
             log.error(">>>> EncryptionService::base64Decode: ", msgUtil.getMessage(EncryptionMsgKey.FAILED_DECODE.getKey(), "base64"));
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(EncryptionMsgKey.FAILED_BASE64_DECODE.getKey()));
+            throw new CustomException(msgUtil.getMessage(EncryptionMsgKey.FAILED_BASE64_DECODE.getKey()), HttpStatus.BAD_REQUEST, e);
         } catch (Exception e) {
             log.error(">>>> EncryptionService::base64Decode: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -118,10 +119,10 @@ public class EncryptionService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), encryptStr);
         } catch (IllegalArgumentException e) {
             log.error(">>>> EncryptionService::hashEncrypt: ", msgUtil.getMessage(EncryptionMsgKey.FAILED_ENCRYPT.getKey(), "hash"));
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(EncryptionMsgKey.FAILED_HASH_ENCRYPT.getKey()));
+            throw new CustomException(msgUtil.getMessage(EncryptionMsgKey.FAILED_HASH_ENCRYPT.getKey()), HttpStatus.BAD_REQUEST, e);
         } catch (Exception e) {
             log.error(">>>> EncryptionService::hashEncrypt: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -132,10 +133,10 @@ public class EncryptionService {
             return ApiResponse.success(msgUtil.getMessage((HashUtil.matches(dto.getTargetText(), dto.getTargetHash(), dto.getAlgorithm().getAlgorithm()) ? EncryptionMsgKey.SUCCUESS_MATCHES_Y.getKey() : EncryptionMsgKey.SUCCUESS_MATCHES_N.getKey())));
         } catch (IllegalArgumentException e) {
             log.error(">>>> EncryptionService::hashMatches: ", msgUtil.getMessage(EncryptionMsgKey.FAILED_ENCRYPT.getKey(), "hash"));
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(EncryptionMsgKey.FAILED_HASH_ENCRYPT.getKey()));
+            throw new CustomException(msgUtil.getMessage(EncryptionMsgKey.FAILED_HASH_ENCRYPT.getKey()), HttpStatus.BAD_REQUEST, e);
         } catch (Exception e) {
             log.error(">>>> EncryptionService::hashMatches: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -148,10 +149,10 @@ public class EncryptionService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), encryptStr);
         } catch (IllegalArgumentException | InvalidKeySpecException i) {
             log.error(">>>> EncryptionService::rsaEncrypt: ", msgUtil.getMessage(EncryptionMsgKey.FAILED_ENCRYPT.getKey(), "RSA"));
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(EncryptionMsgKey.FAILED_RSA_ENCRYPT.getKey()));
+            throw new CustomException(msgUtil.getMessage(EncryptionMsgKey.FAILED_RSA_ENCRYPT.getKey()), HttpStatus.BAD_REQUEST, i);
         } catch (Exception e) {
             log.error(">>>> EncryptionService::rsaEncrypt: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -163,10 +164,10 @@ public class EncryptionService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), decryptStr);
         } catch (InvalidKeySpecException e) {
             log.error(">>>> EncryptionService::rsaEncrypt: ", msgUtil.getMessage(EncryptionMsgKey.FAILED_DECRYPT.getKey(), "RSA"));
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(EncryptionMsgKey.FAILED_RSA_DECRYPT.getKey()));
+            throw new CustomException(msgUtil.getMessage(EncryptionMsgKey.FAILED_RSA_DECRYPT.getKey()), HttpStatus.BAD_REQUEST, e);
         } catch (Exception e) {
             log.error(">>>> EncryptionService::rsaDecrypt: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/file/application/FileService.java
+++ b/src/main/java/com/project/demo/api/file/application/FileService.java
@@ -26,6 +26,7 @@ import com.project.demo.common.ApiResponse;
 import com.project.demo.common.BaseDTO;
 import com.project.demo.common.constant.CommonMsgKey;
 import com.project.demo.common.constant.DelYn;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.util.FileUtil;
 import com.project.demo.common.util.MsgUtil;
 
@@ -50,7 +51,7 @@ public class FileService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), fileDtlRepository.findByFileSeq(fileSeq));
         } catch (Exception e) {
             log.error(">>>> FileService::findAllById: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -128,7 +129,7 @@ public class FileService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), entity.getFileSeq());
         } catch (Exception e) {
             log.error(">>>> FileService::create: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -174,11 +175,10 @@ public class FileService {
                 }
             }
 
-
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), fileSeq);
         } catch (Exception e) {
             log.error(">>>> FileService::update: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/log/application/ErrLogService.java
+++ b/src/main/java/com/project/demo/api/log/application/ErrLogService.java
@@ -14,6 +14,7 @@ import com.project.demo.api.log.infrastructure.ErrLogRepository;
 import com.project.demo.common.ApiResponse;
 import com.project.demo.common.constant.CommonConstant.MODEL_KEY;
 import com.project.demo.common.constant.CommonMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.util.MsgUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -45,7 +46,7 @@ public class ErrLogService {
             return ApiResponse.success(dataMap);
         } catch (Exception e) {
             log.error(">>>> ErrLogService::findAll: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -56,7 +57,7 @@ public class ErrLogService {
             return ApiResponse.success(errLogRepository.findByLogSeq(logSeq));
         } catch (Exception e) {
             log.error(">>>> ErrLogService::findById: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -76,7 +77,7 @@ public class ErrLogService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()));
         } catch (Exception e) {
             log.error(">>>> ErrLogService::updateResolve: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/menu/application/MenuService.java
+++ b/src/main/java/com/project/demo/api/menu/application/MenuService.java
@@ -28,6 +28,7 @@ import com.project.demo.api.menu.value.MenuType;
 import com.project.demo.common.ApiResponse;
 import com.project.demo.common.constant.CommonMsgKey;
 import com.project.demo.common.constant.MenuMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.constant.CommonConstant.MODEL_KEY;
 import com.project.demo.common.util.MsgUtil;
 
@@ -74,7 +75,7 @@ public class MenuService {
             return ApiResponse.success(dataMap);
         } catch (Exception e) {
             log.error(">>>> MenuService::findAll: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -87,7 +88,7 @@ public class MenuService {
                         .orElse(ApiResponse.success());
         } catch (Exception e) {
             log.error(">>>> MenuService::findById: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -109,7 +110,7 @@ public class MenuService {
             return ApiResponse.success(level3);
         } catch (Exception e) {
             log.error(">>>> MenuService::findAllByParentId: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -165,7 +166,7 @@ public class MenuService {
             return ApiResponse.success();
         } catch (Exception e) {
             log.error(">>>> MenuService::findAllAsTree: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -238,7 +239,7 @@ public class MenuService {
             }
         } catch (Exception e) {
             log.error(">>>> MenuService::create: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -252,7 +253,7 @@ public class MenuService {
             return ApiResponse.success(msgUtil.getMessage(MenuMsgKey.SUCCUESS_DUPLICATION.getKey(), "메뉴 이름"));
         } catch (Exception e) {
             log.error(">>>> MenuService::checkDuplicateMenuNm: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -266,7 +267,7 @@ public class MenuService {
             return ApiResponse.success(msgUtil.getMessage(MenuMsgKey.SUCCUESS_DUPLICATION.getKey(), "메뉴 URL"));
         } catch (Exception e) {
             log.error(">>>> MenuService::checkDuplicateMenuUrl: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/role/application/MenuRoleService.java
+++ b/src/main/java/com/project/demo/api/role/application/MenuRoleService.java
@@ -23,6 +23,7 @@ import com.project.demo.api.role.application.dto.MenuRoleTreeDTO;
 import com.project.demo.api.role.domain.MenuRoleEntity;
 import com.project.demo.api.role.infrastructure.MenuRoleRepository;
 import com.project.demo.common.constant.DelYn;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.util.MsgUtil;
 import com.project.demo.common.ApiResponse;
 import com.project.demo.common.constant.CommonConstant.CACHE_KEY;
@@ -109,7 +110,7 @@ public class MenuRoleService {
             return ApiResponse.success(list);
         } catch (Exception e) {
             log.error(">>>> MenuRoleService::findMenusById: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 

--- a/src/main/java/com/project/demo/api/role/application/RoleService.java
+++ b/src/main/java/com/project/demo/api/role/application/RoleService.java
@@ -22,6 +22,7 @@ import com.project.demo.common.constant.CommonConstant.MODEL_KEY;
 import com.project.demo.common.constant.CommonMsgKey;
 import com.project.demo.common.constant.DelYn;
 import com.project.demo.common.constant.MenuMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.util.MsgUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -53,7 +54,7 @@ public class RoleService {
             return ApiResponse.success(dataMap);
         } catch (Exception e) {
             log.error(">>>> RoleService::findAll: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -64,7 +65,7 @@ public class RoleService {
             return ApiResponse.success(roleRepository.findByRoleSeq(roleSeq));
         } catch (Exception e) {
             log.error(">>>> RoleService::findById: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -86,7 +87,7 @@ public class RoleService {
             return ApiResponse.success(msgUtil.getMessage(MenuMsgKey.SUCCUESS_DUPLICATION.getKey(), "권한 이름"));
         } catch (Exception e) {
             log.error(">>>> RoleService::checkDuplicate: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -108,7 +109,7 @@ public class RoleService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), entity.getRoleSeq());
         } catch (Exception e) {
             log.error(">>>> RoleService::create: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -131,7 +132,7 @@ public class RoleService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()), dto.getRoleSeq());
         } catch (Exception e) {
             log.error(">>>> RoleService::update: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -154,7 +155,7 @@ public class RoleService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()));
         } catch (Exception e) {
             log.error(">>>> RoleService::delete: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -168,7 +169,7 @@ public class RoleService {
                                                         .collect(Collectors.toList()));
         } catch (Exception e) {
             log.error(">>>> RoleService::getRole: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/user/application/SignupService.java
+++ b/src/main/java/com/project/demo/api/user/application/SignupService.java
@@ -14,6 +14,7 @@ import com.project.demo.api.user.infrastructure.SignupRepository;
 import com.project.demo.common.ApiResponse;
 import com.project.demo.common.constant.CommonMsgKey;
 import com.project.demo.common.constant.SignupMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.util.MsgUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -105,7 +106,7 @@ public class SignupService {
             return ApiResponse.success(msgUtil.getMessage(SignupMsgKey.SUCCESS.getKey()));
         } catch (Exception e) {
             log.error(">>>> singup: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/api/user/application/UserService.java
+++ b/src/main/java/com/project/demo/api/user/application/UserService.java
@@ -21,6 +21,7 @@ import com.project.demo.common.ApiResponse;
 import com.project.demo.common.BaseDTO;
 import com.project.demo.common.constant.CommonConstant.MODEL_KEY;
 import com.project.demo.common.constant.CommonMsgKey;
+import com.project.demo.common.exception.CustomException;
 import com.project.demo.common.constant.AuthMsgKey;
 import com.project.demo.common.util.MsgUtil;
 
@@ -66,7 +67,7 @@ public class UserService {
             return ApiResponse.success(dataMap);
         } catch (Exception e) {
             log.error(">>>> UserService::findAll: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -77,7 +78,7 @@ public class UserService {
             return ApiResponse.success(userRepository.findByUserSeq(userSeq));
         } catch (Exception e) {
             log.error(">>>> UserService::findById: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -108,7 +109,7 @@ public class UserService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()));
         } catch (Exception e) {
             log.error(">>>> UserService::passwordInit: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -126,7 +127,7 @@ public class UserService {
             return ApiResponse.success(dto.getUserSeq());
         } catch (Exception e) {
             log.error(">>>> UserService::update: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -157,7 +158,7 @@ public class UserService {
             return ApiResponse.success(entity.getUserSeq());
         } catch (Exception e) {
             log.error(">>>> UserService::create: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -171,7 +172,7 @@ public class UserService {
             return findById(dto.getUserSessionDTO().getUserSeq());
         } catch (Exception e) {
             log.error(">>>> UserService::findByMe: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 
@@ -189,7 +190,7 @@ public class UserService {
             return ApiResponse.success(msgUtil.getMessage(CommonMsgKey.SUCCUESS.getKey()));
         } catch (Exception e) {
             log.error(">>>> UserService::updateMe: ", e);
-            return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, msgUtil.getMessage(CommonMsgKey.FAILED.getKey()));
+            throw new CustomException(msgUtil.getMessage(CommonMsgKey.FAILED.getKey()), HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/project/demo/common/exception/CustomException.java
+++ b/src/main/java/com/project/demo/common/exception/CustomException.java
@@ -13,4 +13,9 @@ public class CustomException extends RuntimeException {
         super(message);
         this.status = status;
     }
+
+    public CustomException(String message, HttpStatus status, Throwable cause) {
+        super(message, cause); // 원인 예외 포함
+        this.status = status;
+    }
 }

--- a/src/main/java/com/project/demo/common/exception/GlobalViewExceptionHandler.java
+++ b/src/main/java/com/project/demo/common/exception/GlobalViewExceptionHandler.java
@@ -1,0 +1,123 @@
+package com.project.demo.common.exception;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import com.project.demo.api.log.domain.ErrLogEntity;
+import com.project.demo.api.log.infrastructure.ErrLogRepository;
+import com.project.demo.api.log.value.ErrLevel;
+import com.project.demo.common.constant.CommonConstant.SESSION_KEY;
+import com.project.demo.config.security.application.dto.UserSessionDTO;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@ControllerAdvice(basePackages = "com.project.demo.web")
+@RequiredArgsConstructor
+@Slf4j
+public class GlobalViewExceptionHandler {
+
+    private final ErrLogRepository errLogRepository;
+
+    /**
+     * 모든 예외 처리
+     * @param ex
+     * @param request
+     * @param httpServletRequest
+     * @return
+     */
+    @ExceptionHandler(Exception.class)
+    public String handleViewException(Exception ex, HttpServletRequest request, ModelMap model) {
+
+        HttpStatus status = getHttpStatus(ex);
+
+        // 로그 저장
+        logErrorToDatabase(ex, request, status);
+
+        // 사용자에게 보여줄 메시지 설정
+        model.addAttribute("errorMessage", ex.getMessage());
+
+        // 상태 코드별로 분기 가능
+        if (status == HttpStatus.NOT_FOUND) {
+            return "/error/404";
+        } else if (status == HttpStatus.FORBIDDEN) {
+            return "/error/403";
+        } else if ( status == HttpStatus.INTERNAL_SERVER_ERROR ) {
+            return "/error/500";
+        }
+
+        return "/error/default";
+    }
+
+    /**
+     * 공통 에러 로그 저장 로직
+     * @param ex
+     * @param request
+     * @param status
+     */
+    private void logErrorToDatabase(Exception ex, HttpServletRequest request, HttpStatus status) {
+        // 스택 트레이스 변환
+        StringWriter sw = new StringWriter();
+        ex.printStackTrace(new PrintWriter(sw));
+        String stackTrace = sw.toString();
+
+        // 로그인 사용자 userSeq 취득
+        Long userSeq = null;
+        UserSessionDTO userSessionDTO = (UserSessionDTO) request.getSession().getAttribute(SESSION_KEY.FRONT);
+        if ( userSessionDTO != null )
+            userSeq = userSessionDTO.getUserSeq();
+
+        ErrLogEntity logEntity = ErrLogEntity.builder()
+                .errCd(String.valueOf(status.value()))
+                .errMsg(ex.getMessage())
+                .stackTrace(stackTrace)
+                .errLevel(determineErrorLevel(status))
+                .occurredDt(LocalDateTime.now())
+                .requestUrl(request.getRequestURI())
+                .requestMethod(request.getMethod())
+                .requestSeq(userSeq)
+                .build();
+
+        // err log 저장
+        errLogRepository.save(logEntity);
+    }
+
+    /**
+     * 예외에서 HTTP 상태 코드 추출
+     * @param ex
+     * @return
+     */
+    private HttpStatus getHttpStatus(Exception ex) {
+        ResponseStatus status = ex.getClass().getAnnotation(ResponseStatus.class);
+
+        if (status != null) 
+            return status.value();
+
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    /**
+     * HTTP 상태 코드에 따른 에러 레벨 분류
+     * @param status
+     * @return
+     */
+    public ErrLevel determineErrorLevel(HttpStatus status) {
+        if ( status.is5xxServerError() ) {
+            return ErrLevel.CRITICAL;
+        } else if ( status == HttpStatus.BAD_REQUEST || status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN ) {
+            return ErrLevel.WARN;
+        } else if ( status == HttpStatus.NOT_FOUND ) {
+            return ErrLevel.INFO;
+        }
+
+        return ErrLevel.ERROR;
+    }
+}

--- a/src/main/java/com/project/demo/web/error/CustomErrorController.java
+++ b/src/main/java/com/project/demo/web/error/CustomErrorController.java
@@ -35,4 +35,10 @@ public class CustomErrorController {
         
         return "/error/sessionTimeOut";
     }
+
+    @GetMapping("/403")
+    public String error403() {
+
+        return "/error/403";
+    }
 }


### PR DESCRIPTION
…d proper exception propagation

- Separated GlobalExceptionHandler into API-specific and View-specific handlers
- Updated service layer to throw exceptions instead of swallowing them